### PR TITLE
chore(publish): `npm run build` before publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 bin
+dist
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git

--- a/package.json
+++ b/package.json
@@ -2,12 +2,16 @@
   "name": "push.js",
   "version": "0.0.1",
   "description": "A compact, cross-browser solution for Javascript desktop notifications",
-  "main": "bin/push.js",
+  "main": "dist/push.js",
   "scripts": {
-    "clean": "shx rm -rf bin",
-    "build": "shx rm -rf bin && shx mkdir -p bin && shx cp push.js bin/. && uglifyjs push.js -o bin/push.min.js",
-    "test": "karma start"
+    "clean": "shx rm -rf dist",
+    "build": "shx rm -rf dist && shx mkdir -p dist && shx cp push.js dist/. && uglifyjs push.js -o dist/push.min.js",
+    "test": "karma start",
+    "prepublish": "npm run build"
   },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Nickersoft/push.js"


### PR DESCRIPTION
the generated dir is named as `dist` instead of `bin`

fixes #4, #7 

