### PR TITLE
Fix callback is not defined error

### DIFF
--- a/push.js
+++ b/push.js
@@ -360,6 +360,7 @@
          */
         self.Permission.request = function (onGranted, onDenied) {
             var existing = self.Permission.get();
+            var callback;
 
             /* Return if Push not supported */
             if (!self.isSupported) {


### PR DESCRIPTION
When using `Push.Permission.request` I was getting callback is not defined. Just added a `var` to initialize it.