### PR TITLE
Update typings for default export and config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'push.js' {
 
-    export default new Push();
+    const defaultPush: Push;
+    export default defaultPush;
 
     class Push {
         Permission: PushPermission;
@@ -11,7 +12,7 @@ declare module 'push.js' {
 
         clear(): void;
 
-        config(params: PushParams)
+        config(params: PushParams): void;
     }
 
     export interface PushNotificationParams {


### PR DESCRIPTION
The current index.d.ts file, when compiled with TypeScript 3.1, would give the following error:

```
./node_modules/push.js/index.d.ts:3:20
    TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
./node_modules/push.js/index.d.ts:14:9
    TS7010: 'config', which lacks return-type annotation, implicitly has an 'any' return type.
```
I attempted a minimal fix to the above problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nickersoft/push.js/189)
<!-- Reviewable:end -->
