### PR TITLE
Handle deprecated requestPermission APi in Safari 12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - secure: AwJJp7im+vXzxa/UsYu/EJNppu+ss9l0GW8ftaXLNnMRkLJyo6m24DCJuhfH/ynxrSq5b2Zc7gEqDfxVWUgpNR+rrHZoHe+R/QnL60sqQXE2KvblDvG4o4e9F7vFp1xsohJ3/TTm6footWEiVlP25oVkQgi/oWhFsygJD6VGerDa2CodtU2r4p6UV5KuI8mUZuQg+rndkosMZa1BkZcz6v8e1AmJkGiIl/Agw0ye6C9iav4KoU+EXRyoxEq+dTAuhnVKA3CntOngoPDrUTQy5303x6Gzaz7uByWIyIR+uEud65RvCBduxCgREazkXdCqd/vCS65gYYktxl3fNG2so5VpKAbF/pTOylWexB10xhB+k+alIxhl3QytUx1pqDR4WI6c8d6ot+sZd7AjwvlyWdwDPuLoDB2eA18K3HbFMgjONmJFFI3gyKfyg1z5FfZm6dogfuQGZeSyxuedDAo+FygKGbgvBa+JHerR1WjU+TnFcVpwgaX/sma8Q4ff9WYLw2YOIiSi0H5V5tDi8lrtOqZmIYH4Vv2Cbl1gaAsVOOo+IBfTWor4oJzAb/jRKuNbqvhUJIqW6RYS7f8c/LMrcdn+LWHGj3zcFQ+LNFxID4OCghf7A3FvmE8A5XD07w04ofnWzrgqzgWy5+38Qj23l5IpFNgD2XGNohk7JpeGm3E=
 language: node_js
 node_js:
-- lts/*
+- "8.12"
 before_install: yarn global add greenkeeper-lockfile@1
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -51,6 +51,7 @@ export default class Permission {
                 if (onGranted) onGranted();
             } else if (onDenied) onDenied();
         };
+        var request;
 
         /* Permissions already set */
         if (existing !== this.DEFAULT) {
@@ -68,7 +69,7 @@ export default class Permission {
             /* Safari 12+ */
             /* This resolve argument will only be used in Safari */
             /* CHrome, instead, returns a Promise */
-            var request = this._win.Notification.requestPermission(resolve);
+            request = this._win.Notification.requestPermission(resolve);
             if (request && request.then) {
                 /* Chrome 23+ */
                 request.then(resolve).catch(function() {
@@ -109,6 +110,7 @@ export default class Permission {
                 resolved = true;
                 isGranted(result) ? resolvePromise() : rejectPromise();
             };
+            var request;
 
             if (hasPermissions) {
                 resolver(existing);
@@ -120,7 +122,7 @@ export default class Permission {
                 /* Safari 12+ */
                 /* This resolver argument will only be used in Safari */
                 /* CHrome, instead, returns a Promise */
-                var request = this._win.Notification.requestPermission(resolver);
+                request = this._win.Notification.requestPermission(resolver);
                 if (request && request.then) {
                     /* Chrome 23+ */
                     request.then(resolver).catch(rejectPromise);

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -68,7 +68,7 @@ export default class Permission {
             /* Safari 12+ */
             /* This resolve argument will only be used in Safari */
             /* CHrome, instead, returns a Promise */
-            const request = this._win.Notification.requestPermission(resolve);
+            var request = this._win.Notification.requestPermission(resolve);
             if (request && request.then) {
                 /* Chrome 23+ */
                 request.then(resolve).catch(function() {
@@ -120,7 +120,7 @@ export default class Permission {
                 /* Safari 12+ */
                 /* This resolver argument will only be used in Safari */
                 /* CHrome, instead, returns a Promise */
-                const request = this._win.Notification.requestPermission(resolver);
+                var request = this._win.Notification.requestPermission(resolver);
                 if (request && request.then) {
                     /* Chrome 23+ */
                     request.then(resolver).catch(rejectPromise);

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -41,13 +41,17 @@ export default class Permission {
     _requestWithCallback(onGranted: () => void, onDenied: () => void) {
         const existing = this.get();
 
+        var resolved = false;
         var resolve = (result = this._win.Notification.permission) => {
+            if (resolved) return;
+            resolved = true;
             if (typeof result === 'undefined' && this._win.webkitNotifications)
                 result = this._win.webkitNotifications.checkPermission();
             if (result === this.GRANTED || result === 0) {
                 if (onGranted) onGranted();
             } else if (onDenied) onDenied();
         };
+        var request;
 
         /* Permissions already set */
         if (existing !== this.DEFAULT) {
@@ -62,13 +66,14 @@ export default class Permission {
             this._win.Notification &&
             this._win.Notification.requestPermission
         ) {
-            /* Chrome 23+ */
-            this._win.Notification
-                .requestPermission()
-                .then(resolve)
-                .catch(function() {
+            /* Safari 12+ */
+            request = this._win.Notification.requestPermission(resolve);
+            if (request && request.then) {
+                /* Chrome 23+ */
+                request.catch(function() {
                     if (onDenied) onDenied();
                 });
+            }
         } else if (onGranted) {
             /* Let the user continue by default */
             onGranted();
@@ -97,8 +102,13 @@ export default class Permission {
             this._win.webkitNotifications.checkPermission;
 
         return new Promise((resolvePromise, rejectPromise) => {
-            var resolver = result =>
+            var resolved = false;
+            var resolver = result => {
+                if (resolved) return;
+                resolved = true;
                 isGranted(result) ? resolvePromise() : rejectPromise();
+            };
+            var request;
 
             if (hasPermissions) {
                 resolver(existing);
@@ -107,12 +117,12 @@ export default class Permission {
                     resolver(result);
                 });
             } else if (isModernAPI) {
-                this._win.Notification
-                    .requestPermission()
-                    .then(result => {
-                        resolver(result);
-                    })
-                    .catch(rejectPromise);
+                /* Safari 12+ */
+                request = this._win.Notification.requestPermission(resolver);
+                if (request && request.then) {
+                    /* Chrome 23+ */
+                    request.then(resolver).catch(rejectPromise);
+                }
             } else resolvePromise();
         });
     }

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -70,7 +70,7 @@ export default class Permission {
             request = this._win.Notification.requestPermission(resolve);
             if (request && request.then) {
                 /* Chrome 23+ */
-                request.catch(function() {
+                request.then(resolve).catch(function() {
                     if (onDenied) onDenied();
                 });
             }

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -66,6 +66,8 @@ export default class Permission {
             this._win.Notification.requestPermission
         ) {
             /* Safari 12+ */
+            /* This resolve argument will only be used in Safari */
+            /* CHrome, instead, returns a Promise */
             const request = this._win.Notification.requestPermission(resolve);
             if (request && request.then) {
                 /* Chrome 23+ */
@@ -116,6 +118,8 @@ export default class Permission {
                 });
             } else if (isModernAPI) {
                 /* Safari 12+ */
+                /* This resolver argument will only be used in Safari */
+                /* CHrome, instead, returns a Promise */
                 const request = this._win.Notification.requestPermission(resolver);
                 if (request && request.then) {
                     /* Chrome 23+ */

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -51,7 +51,6 @@ export default class Permission {
                 if (onGranted) onGranted();
             } else if (onDenied) onDenied();
         };
-        var request;
 
         /* Permissions already set */
         if (existing !== this.DEFAULT) {
@@ -67,7 +66,7 @@ export default class Permission {
             this._win.Notification.requestPermission
         ) {
             /* Safari 12+ */
-            request = this._win.Notification.requestPermission(resolve);
+            const request = this._win.Notification.requestPermission(resolve);
             if (request && request.then) {
                 /* Chrome 23+ */
                 request.then(resolve).catch(function() {

--- a/src/push/Permission.js
+++ b/src/push/Permission.js
@@ -107,7 +107,6 @@ export default class Permission {
                 resolved = true;
                 isGranted(result) ? resolvePromise() : rejectPromise();
             };
-            var request;
 
             if (hasPermissions) {
                 resolver(existing);
@@ -117,7 +116,7 @@ export default class Permission {
                 });
             } else if (isModernAPI) {
                 /* Safari 12+ */
-                request = this._win.Notification.requestPermission(resolver);
+                const request = this._win.Notification.requestPermission(resolver);
                 if (request && request.then) {
                     /* Chrome 23+ */
                     request.then(resolver).catch(rejectPromise);


### PR DESCRIPTION
The assumption was that Safari would not remove the webkit prefix
without also conforming to the promise-based requestPermission API. They
dropped the prefix and did not update to Promises. This checks the
return value of the requestPermission call and treats it as a Promise
when possible. Otherwise, it always passes the callback version for the
old API.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission

Ref: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/LocalNotifications/LocalNotifications.html#//apple_ref/doc/uid/TP40012932-SW1

Fixes #117 and #124, tested in modern Safari, Chrome, FF, IE. 

Re-open of #190 with fewer edits.