### PR TITLE
Added the silent option to the desktop agent

### DIFF
--- a/src/agents/DesktopAgent.js
+++ b/src/agents/DesktopAgent.js
@@ -34,7 +34,8 @@ export default class DesktopAgent extends AbstractAgent {
                     : options.icon.x32,
             body: options.body,
             tag: options.tag,
-            requireInteraction: options.requireInteraction
+            requireInteraction: options.requireInteraction,
+            silent: options.silent
         });
     }
 


### PR DESCRIPTION
Simple fix to add the silent option to the desktop agent

tested in Chrome 94